### PR TITLE
Set host header needed for geoserver pdf print

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -25,6 +25,7 @@ server {
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Server $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $host;
         proxy_pass http://127.0.0.1:8080/geoserver/;
         add_header Access-Control-Allow-Origin "*";
     }


### PR DESCRIPTION
In order to make PDF printing using Geoserver work from GeoExplorer, I needed to also set the `Host` header in the Nginx configuration. Otherwise the `printURL` provided by the `/geoserver/pdf/info.json` response will point to localhost (e.g. http://127.0.0.1:8080/geoserver/pdf/1234567890.pdf.printout`. GeoExplorer will subsequently try to redirect to this URL, resulting in a page error.