### PR TITLE
Refactoring with ansible lint tag resources

### DIFF
--- a/tasks/geonode.yml
+++ b/tasks/geonode.yml
@@ -53,11 +53,17 @@
   template: src=local_settings.py.j2 dest={{app_code_dir}}/{{app_name}}/{{app_name}}/local_settings.py
 
 - name: patch allowed hosts in settings.py
-  shell: sed -i -e "s/ALLOWED_HOSTS = os.getenv('ALLOWED_HOSTS', \['localhost', \])/ALLOWED_HOSTS = os.getenv('ALLOWED_HOSTS', \['localhost', '{{ server_name }}'\])/g" {{app_code_dir}}/{{app_name}}/{{app_name}}/settings.py
+  replace:
+    path: "{{ app_code_dir }}/{{ app_name }}/{{ app_name }}/settings.py"
+    regexp: "ALLOWED_HOSTS = os.getenv('ALLOWED_HOSTS', ['localhost', ])"
+    replace: "ALLOWED_HOSTS = os.getenv('ALLOWED_HOSTS', ['localhost', '{{ server_name }}'])"
   when: github_user != "GeoNode"
 
 - name: patch hostname in settings.py
-  shell: sed -i -e "s/localhost:8080/{{ server_name }}/g" {{app_code_dir}}/{{app_name}}/{{app_name}}/settings.py
+  replace:
+    path: "{{ app_code_dir }}/{{ app_name }}/{{ app_name }}/settings.py"
+    regexp: localhost:8080
+    replace: "{{ server_name }}"
   when: github_user != "GeoNode"
 
 - name: install default geonode version {{geonode_version}}

--- a/tasks/geonode.yml
+++ b/tasks/geonode.yml
@@ -192,9 +192,10 @@
                  settings={{main_module}}.settings
 
 - name: wait for geoserver to be up
-  shell: curl --head --silent http://localhost:8080/geoserver/web/
+  uri:
+    url: http://localhost:8080/geoserver/web/
   register: result
-  until: result.stdout.find('HTTP/1.1 200') != -1
+  until: result.status == 200
   retries: 5
   delay: 60
 

--- a/tasks/geoserver.yml
+++ b/tasks/geoserver.yml
@@ -14,8 +14,11 @@
   become: yes
 
 - name: change default-java to openjdk8
+  file:
+    path: /usr/lib/jvm/default-java
+    src: /usr/lib/jvm/java-8-openjdk-amd64
+    state: link
   become: yes
-  shell: rm /usr/lib/jvm/default-java && ln -s /usr/lib/jvm/java-8-openjdk-amd64 /usr/lib/jvm/default-java
 
 - name: install tomcat
   apt:

--- a/tasks/geoserver.yml
+++ b/tasks/geoserver.yml
@@ -116,24 +116,16 @@
     path: /var/lib/tomcat8/webapps/geoserver/data/security/filter/geonode-oauth2/config.xml
   register: geonode_oauth_file
 
-- name: patch the geonode-oauth file (geoserver part)
+- name: patch the geonode files
+  replace:
+    path: "{{ item }}"
+    regexp: http://localhost:8080
+    replace: http://{{ server_name }}
   become: yes
-  shell: sed -i -e "s|http://localhost:8080|http://{{ server_name }}|g" /var/lib/tomcat8/webapps/geoserver/data/security/filter/geonode-oauth2/config.xml
-  when: geonode_oauth_file.stat.exists
-
-- name: patch the geonode-oauth file (geonode part)
-  become: yes
-  shell: sed -i -e "s|http://localhost:8000|http://{{ server_name }}|g" /var/lib/tomcat8/webapps/geoserver/data/security/filter/geonode-oauth2/config.xml
-  when: geonode_oauth_file.stat.exists
-
-- name: patch the geonode-role file
-  become: yes
-  shell: sed -i -e "s|http://localhost:8000|http://{{ server_name }}|g" /var/lib/tomcat8/webapps/geoserver/data/security/role/geonode\ REST\ role\ service/config.xml
-  when: geonode_oauth_file.stat.exists
-
-- name: patch the geoserver global config file
-  become: yes
-  shell: sed -i -e "s|http://localhost:8080|http://{{ server_name }}|g" /var/lib/tomcat8/webapps/geoserver/data/global.xml
+  loop:
+  - /var/lib/tomcat8/webapps/geoserver/data/security/filter/geonode-oauth2/config.xml
+  - /var/lib/tomcat8/webapps/geoserver/data/security/role/geonode REST role service/config.xml
+  - /var/lib/tomcat8/webapps/geoserver/data/global.xml
   when: geonode_oauth_file.stat.exists
 
 # - name: remove masterpw.info file to remove security risk warning


### PR DESCRIPTION
Refactored a few areas where more appropriate modules were available.

Looks to be an issue with these sections, as they both reference the same file

tasks/geoserver.yml 
- name: patch the geonode-oauth file (geonode part)
- name: patch the geonode-oauth file (geoserver part)


Tested with the following command.

$ ansible-lint -t resources geonode-v2.yml
```
---
- hosts: webservers
  remote_user: ubuntu
  vars:
    app_name: my_geonode
    github_user: GeoNode
  roles:
    - { role: geonode.geonode-unwind }

```